### PR TITLE
Remove unnecessary `use` statements.

### DIFF
--- a/class-vip-support-cli.php
+++ b/class-vip-support-cli.php
@@ -1,8 +1,5 @@
 <?php
 
-use \WP_CLI_Command;
-use \WP_User_Query;
-
 /**
  * Implements a WP CLI command that converts guid users to meta users
  * Class command


### PR DESCRIPTION
These classes should already be in the global namespace, so we shouldn't need to explicitly state that we're using them.

Fixes #22.