### PR TITLE
Have the role check check the role

### DIFF
--- a/class-vip-support-user.php
+++ b/class-vip-support-user.php
@@ -410,12 +410,12 @@ class WPCOM_VIP_Support_User {
 	public function action_profile_update( $user_id ) {
 		$user = new WP_User( $user_id );
 		$verified_email = get_user_meta( $user_id, self::META_EMAIL_VERIFIED, true );
-		if ( $user->user_email != $verified_email && $user->has_cap( WPCOM_VIP_Support_Role::VIP_SUPPORT_ROLE ) ) {
+		if ( $user->user_email !== $verified_email && $this->user_has_vip_support_role( $user_id ) ) {
 			$user->set_role( WPCOM_VIP_Support_Role::VIP_SUPPORT_INACTIVE_ROLE );
 			$this->message_replace = self::MSG_DOWNGRADE_VIP_USER;
 			delete_user_meta( $user_id, self::META_EMAIL_VERIFIED );
 			delete_user_meta( $user_id, self::META_VERIFICATION_DATA );
-			if ( $user->has_cap( WPCOM_VIP_Support_Role::VIP_SUPPORT_ROLE ) || $user->has_cap( WPCOM_VIP_Support_Role::VIP_SUPPORT_INACTIVE_ROLE ) ) {
+			if ( $this->user_has_vip_support_role( $user_id ) || $this->user_has_vip_support_role( $user_id, false ) ) {
 				$this->send_verification_email( $user_id );
 			}
 		}


### PR DESCRIPTION
Refactors the role check to actually check the list of roles the user has, rather than using Core's `user_can` method/function, which is easily fooled by Super Admin users.
