### PR TITLE
CLI command to add a support user easily

### DIFF
--- a/class-vip-support-cli.php
+++ b/class-vip-support-cli.php
@@ -95,7 +95,7 @@ class WPCOM_VIP_Support_CLI  extends WP_CLI_Command {
 			\WP_CLI::error( "Could not find a user with ID $user_id" );
 		}
 
-		WPCOM_VIP_Support_User::init()->mark_user_email_verified( $user->user_id, $user->user_email );
+		WPCOM_VIP_Support_User::init()->mark_user_email_verified( $user->ID, $user->user_email );
 
 		// Print a success message
 		\WP_CLI::success( "Verified user $user_id with email {$user->user_email}, you can now change their role to VIP Support" );


### PR DESCRIPTION
Sends no verification emails
Verifies the user after creation as A8c
Generates a random 64 digit password if none is provided
Emails the site admin, because transparency is good
