### PR TITLE
Correct logic error so plugin logs less

### DIFF
--- a/class-vip-support-role.php
+++ b/class-vip-support-role.php
@@ -123,7 +123,7 @@ class WPCOM_VIP_Support_Role {
 	 * @param string $message The message to log
 	 */
 	protected static function error_log( $message ) {
-		if ( defined( 'WP_DEBUG' ) || WP_DEBUG ) {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			error_log( $message );
 		}
 


### PR DESCRIPTION
Previously it logged when WP_DEBUG was either defined
OR true. Now it only logs when it's defined AND true.