### PR TITLE
Rename CLI command to `vip support`

### DIFF
--- a/class-vip-support-cli.php
+++ b/class-vip-support-cli.php
@@ -181,4 +181,4 @@ class WPCOM_VIP_Support_CLI  extends WP_CLI_Command {
 
 }
 
-\WP_CLI::add_command( 'vipsupport', 'WPCOM_VIP_Support_CLI' );
+\WP_CLI::add_command( 'vip support', 'WPCOM_VIP_Support_CLI' );


### PR DESCRIPTION
Fixes #46 

While we're deploying, we may want to register the command under both names so nothing breaks while we update the API.