### PR TITLE
filter_user_has_cap: $caps may be null

### DIFF
--- a/class-vip-support-role.php
+++ b/class-vip-support-role.php
@@ -86,7 +86,7 @@ class WPCOM_VIP_Support_Role {
 	 *
 	 * @return array An array of all the user's caps, with the required cap added
 	 */
-	public function filter_user_has_cap( array $user_caps, array $caps, array $args, WP_User $user ) {
+	public function filter_user_has_cap( array $user_caps, $caps, $args, $user ) {
 		if ( in_array( self::VIP_SUPPORT_ROLE, $user->roles ) && is_proxied_automattician() ) {
 			foreach ( $caps as $cap ) {
 				$user_caps[$cap] = true;


### PR DESCRIPTION
If $caps is null, we get a fatal error:

```
PHP Fatal error:  Uncaught TypeError: Argument 2 passed to WPCOM_VIP_Support_Role::filter_user_has_cap() must be of the type     array, null given, called in /var/www/wp-includes/class-wp-hook.php on line 298 and defined in /var/www/wp-content/mu-plugins/vip-support/class-vip-support-role.php:89
```