### PR TITLE
Don't error if user has already been deleted

### DIFF
--- a/class-vip-support-cli.php
+++ b/class-vip-support-cli.php
@@ -119,7 +119,7 @@ class WPCOM_VIP_Support_CLI  extends WP_CLI_Command {
 		$user = get_user_by( 'email', $user_email );
 
 		if ( false === $user ) {
-			\WP_CLI::error( "No user exists with the email address {$user_email}, so they could not be deleted" );
+			\WP_CLI::line( "No user exists with the email address {$user_email}, so they could not be deleted" );
 		}
 
 		// Check user has the active or inactive VIP Support role,

--- a/class-vip-support-cli.php
+++ b/class-vip-support-cli.php
@@ -119,7 +119,8 @@ class WPCOM_VIP_Support_CLI  extends WP_CLI_Command {
 		$user = get_user_by( 'email', $user_email );
 
 		if ( false === $user ) {
-			\WP_CLI::line( "No user exists with the email address {$user_email}, so they could not be deleted" );
+			\WP_CLI::warning( "No user exists with the email address {$user_email}, so they could not be deleted" );
+			return;
 		}
 
 		// Check user has the active or inactive VIP Support role,


### PR DESCRIPTION
We just want the remove-user command to ensure the support user in question has been removed. If they don't exist, we can note that in the output, but shouldn't error because it causes vipd host actions to fail. An easy way to get into this scenario is just to add two support users in a row. Both times we'll queue a second action to delete the user later, but the second `remove-user` will fail.