### PR TITLE
Blacklist certain capabilities that conflict with the platform

### DIFF
--- a/class-vip-support-role.php
+++ b/class-vip-support-role.php
@@ -24,6 +24,17 @@ class WPCOM_VIP_Support_Role {
 	const VERSION = 2;
 
 	/**
+	 * Capabilities that even VIP Support shouldn't have
+	 *
+	 * ie, filesystem is read-only, regardless of WP role
+	 */
+	const BANNED_CAPABILITIES = array(
+		'edit_files',
+		'edit_plugins',
+		'edit_themes',
+	);
+
+	/**
 	 * Initiate an instance of this class if one doesn't
 	 * exist already. Return the VipSupportRole instance.
 	 *
@@ -88,6 +99,8 @@ class WPCOM_VIP_Support_Role {
 	 */
 	public function filter_user_has_cap( array $user_caps, array $caps, array $args, WP_User $user ) {
 		if ( in_array( self::VIP_SUPPORT_ROLE, $user->roles ) && is_proxied_automattician() ) {
+			$caps = array_diff( $caps, self::BANNED_CAPABILITIES );
+
 			foreach ( $caps as $cap ) {
 				$user_caps[$cap] = true;
 			}


### PR DESCRIPTION
Certain capabilities, such as those related to filesystem modifications, don't make sense for even VIP Support users, as the filesystem is read-only.

Fixes #52