### PR TITLE
Only log removals if we did any

### DIFF
--- a/class-vip-support-user.php
+++ b/class-vip-support-user.php
@@ -971,7 +971,9 @@ class User {
 
 		$stale = self::remove_stale_support_users();
 
-		error_log( "VIP Support user removals attempted: \n" . var_export( compact( 'stale' ), true ) );
+		if ( ! empty( $stale ) ) {
+			error_log( "VIP Support user removals attempted: \n" . var_export( compact( 'stale' ), true ) );
+		}
 	}
 }
 


### PR DESCRIPTION
No point in filling up error logs with not-useful entries. Otherwise we end up with tons of these:

```
VIP Support user removals attempted: 
array (
  'stale' => 
  array (
  ),
)
```