### PR TITLE
Hook the custom user_has_cap callback as late as possible

### DIFF
--- a/class-vip-support-role.php
+++ b/class-vip-support-role.php
@@ -67,7 +67,7 @@ class Role {
 		add_action( 'init', array( $this, 'action_init' ) );
 		add_action( 'admin_init', array( $this, 'action_admin_init' ) );
 		add_filter( 'editable_roles', array( $this, 'filter_editable_roles' ) );
-		add_filter( 'user_has_cap', array( $this, 'filter_user_has_cap' ), 10, 4 );
+		add_filter( 'user_has_cap', array( $this, 'filter_user_has_cap' ), PHP_INT_MAX, 4 );
 	}
 
 	// HOOKS


### PR DESCRIPTION
Hooking the the user_has_cap filter from a mu-plugin on default priority means that any theme's or plugin's hook may override ours, as they are being processed in chronological order in terms of a single priority.

This commit moves our callback to `PHP_INT_MAX` priority, which means it should run really late.