### PR TITLE
Don't typecast $user object for wp_login callback

### DIFF
--- a/class-vip-support-user.php
+++ b/class-vip-support-user.php
@@ -527,7 +527,7 @@ class User {
 	 *
 	 * @return void
 	 */
-	public function action_wp_login( $user_login, WP_User $user ) {
+	public function action_wp_login( $user_login, $user ) {
 		if ( ! is_multisite() ) {
 			return;
 		}


### PR DESCRIPTION
Some manually called instances may incorrectly pass in a non-WP_User object which results in fatals:

```
Uncaught TypeError: Argument 2 passed to Automattic\VIP\Support_User\User::action_wp_login() must be an instance of WP_User, boolean given
```