### PR TITLE
Set the first and last name for users

### DIFF
--- a/class-vip-support-cli.php
+++ b/class-vip-support-cli.php
@@ -44,6 +44,8 @@ class Command extends WP_CLI_Command {
 		$user_data['user_login']   = $user_login;
 		$user_data['user_email']   = $user_email;
 		$user_data['display_name'] = $display_name;
+		$user_data['first_name'] = ! empty( $display_name ) ? $display_name : $user_login;
+		$user_data['last_name'] = '(VIP Support)';
 
 		$user_id = User::add( $user_data );
 


### PR DESCRIPTION
With "VIP Support" as the suffix for last name. To help clearly identify Support users.

If display name passed in we use that, otherwise fall back to user_login. Looks something like: `batmoo (VIP Support)`.

Fixes #10 