### PR TITLE
Allow current mentees to bypass is_a8c_email check for VIP Support User

### DIFF
--- a/class-vip-support-user.php
+++ b/class-vip-support-user.php
@@ -647,7 +647,7 @@ class User {
 			'blocking' => true,
 			'headers' => array(
 				'Content-Type' => 'application/json; charset=utf-8',
-				'Authorization' => 'Basic ' . base64_encode( VIP_ZENDESK_EMAIL . '/token:' . VIP_ZENDESK_TOKEN ) );
+				'Authorization' => 'Basic ' . base64_encode( VIP_ZENDESK_EMAIL . '/token:' . VIP_ZENDESK_TOKEN ) ),
 			),
 		));
 

--- a/class-vip-support-user.php
+++ b/class-vip-support-user.php
@@ -651,13 +651,13 @@ class User {
 			)
 		);
 
-		$decoded_response = json_decode($response['body']);
+		$decoded_response = json_decode( $response[ 'body' ] );
 		$allowed_emails = [];
 
-		foreach ($decoded_response->users as $user) {
+		foreach ( $decoded_response->users as $user ) {
 			$allowed_emails[] = $user->email;
 		}
-		wpcom_vip_cache_set('vip_mentees', $allowed_emails, '', 86400);
+		wpcom_vip_cache_set( 'vip_mentees', $allowed_emails, '', 86400 );
 		return $allowed_emails;
 	}
 
@@ -684,7 +684,7 @@ class User {
 
 		// If email is not a8c, check if it belongs to a current mentee
 		$allowed_emails = $this->get_mentees();
-		if (in_array($email, $allowed_emails, true)) {
+		if ( in_array( $email, $allowed_emails, true ) ) {
 			return true;
 		}
 

--- a/class-vip-support-user.php
+++ b/class-vip-support-user.php
@@ -648,7 +648,7 @@ class User {
 			'headers' => array(
 				'Content-Type' => 'application/json; charset=utf-8',
 				'Authorization' => 'Basic ' . base64_encode( VIP_ZENDESK_EMAIL . '/token:' . VIP_ZENDESK_TOKEN ) ),
-			),
+			)
 		);
 
 		$decoded_response = json_decode($response['body']);

--- a/class-vip-support-user.php
+++ b/class-vip-support-user.php
@@ -649,7 +649,7 @@ class User {
 				'Content-Type' => 'application/json; charset=utf-8',
 				'Authorization' => 'Basic ' . base64_encode( VIP_ZENDESK_EMAIL . '/token:' . VIP_ZENDESK_TOKEN ) ),
 			),
-		));
+		);
 
 		$decoded_response = json_decode($response['body']);
 		$allowed_emails = [];

--- a/class-vip-support-user.php
+++ b/class-vip-support-user.php
@@ -635,9 +635,9 @@ class User {
 	 * @return array Array of emails for current Mentees
 	 */
 	protected function get_mentees() {
-		$cached_emails = wpcom_vip_cache_get('vip_mentees');
+		$cached_emails = wpcom_vip_cache_get( 'vip_mentees' );
 
-		if ($cached_emails) {
+		if ( $cached_emails ) {
 		 return $cached_emails;
 		}
 


### PR DESCRIPTION
Possible solution to allow current Mentees to create `vip_support` users without an a8c email.

The three `VIP_ZENDESK_*` constants need to be committed separately. 

An alternative could be either:
1. To save the results of get_mentees() elsewhere to the platform and then just update the array daily (?) via cron to greatly reduce the reliance on the Zendesk API calls. I've set it to cache for a day atm.
2. To have a static array that would need changing when onboarding/offboarding.