### PR TITLE
Don't send new email on Support User creation

### DIFF
--- a/class-vip-support-user.php
+++ b/class-vip-support-user.php
@@ -879,10 +879,6 @@ class User {
 		$user = new WP_User( $user_id );
 		add_action( 'set_user_role', array( self::init(), 'action_set_user_role' ), 10, 3 );
 
-		// Seems polite to notify the admin that a support user got added to their site
-		// @TODO Tailor the notification email so it explains that this is a support user
-		wp_new_user_notification( $user_id, null, 'admin' );
-
 		self::init()->mark_user_email_verified( $user->ID, $user->user_email );
 		$user->set_role( Role::VIP_SUPPORT_ROLE );
 


### PR DESCRIPTION
Leads to more confusion than the politeness is worth since the emails don't include enough detail or context.