### PR TITLE
Add VIP Support Email Aliases

### DIFF
--- a/class-vip-support-user.php
+++ b/class-vip-support-user.php
@@ -467,7 +467,6 @@ class User {
 		}
 
 		if ( isset( $user_email ) && $this->is_vip_support_email_alias( $user_email ) ) {
-			$email_hash = md5( self::VIP_SUPPORT_EMAIL_ADDRESS );
 			return self::VIP_SUPPORT_EMAIL_ADDRESS_GRAVATAR . '?d=mm&r=g&s=' . $args['size'];
 		}
 

--- a/class-vip-support-user.php
+++ b/class-vip-support-user.php
@@ -425,7 +425,7 @@ class User {
 	 * This helps simplify support email aliases in the users list so
 	 * they're not as lengthy and easier to understand at a glance.
 	 *
-	 * @param $email string The email address of a user.
+	 * @param string $email The email address of a user.
 	 *
 	 * @return string
 	 */
@@ -444,9 +444,9 @@ class User {
 	 * Instead of showing the mystery man, get the Gravatar for the
 	 * real `VIP_SUPPORT_EMAIL_ADDRESS` email address.
 	 *
-	 * @param $url         string The Gravatar url.
-	 * @param $id_or_email mixed  The users ID, email, or a WP_User, WP_Post, WP_Comment object.
-	 * @param $args        array  Arguments passed to get_avatar_url(), after processing.
+	 * @param string $url The Gravatar url.
+	 * @param mixed $id_or_email The users ID, email, or a WP_User object.
+	 * @param array $args Arguments passed to get_avatar_url(), after processing.
 	 *
 	 * @return string
 	 */

--- a/class-vip-support-user.php
+++ b/class-vip-support-user.php
@@ -94,6 +94,11 @@ class User {
 	const VIP_SUPPORT_USER_META_KEY = '_vip_support_user';
 
 	/**
+	 * Base email address for VIP Support user aliases.
+	 */
+	const VIP_SUPPORT_EMAIL_ADDRESS = 'vip-support@automattic.com';
+
+	/**
 	 * A flag to indicate reversion and then to prevent recursion.
 	 *
 	 * @var bool True if the role is being reverted
@@ -163,6 +168,8 @@ class User {
 
 		add_filter( 'wp_redirect',          array( $this, 'filter_wp_redirect' ) );
 		add_filter( 'removable_query_args', array( $this, 'filter_removable_query_args' ) );
+		add_filter( 'user_email',           array( $this, 'filter_vip_support_email_aliases' ) );
+		add_filter( 'get_avatar_url',       array( $this, 'filter_vip_support_email_gravatars' ), 10, 3 );
 
 		$this->reverting_role   = false;
 		$this->message_replace  = false;
@@ -398,6 +405,62 @@ class User {
 			$location = esc_url_raw( $location );
 		}
 		return $location;
+	}
+
+	/**
+	 * Filters a users email address, removing the username if the email
+	 * is a VIP Support email alias.
+	 *
+	 * This helps simplify support email aliases in the users list so
+	 * they're not as lengthy and easier to understand at a glance.
+	 *
+	 * @param $email string The email address of a user.
+	 *
+	 * @return string
+	 */
+	public function filter_vip_support_email_aliases( $email ) {
+		if ( is_admin() && $this->is_vip_support_email_alias( $email ) ) {
+			return self::VIP_SUPPORT_EMAIL_ADDRESS;
+		}
+		return $email;
+	}
+
+	/**
+	 * Filters a users Gravatar URL, altering it if the email is a VIP
+	 * Support email alias.
+	 *
+	 * Since the email aliases are fake, they don't have a Gravatar.
+	 * Instead of showing the mystery man, get the Gravatar for the
+	 * real `VIP_SUPPORT_EMAIL_ADDRESS` email address.
+	 *
+	 * @param $url         string The Gravatar url.
+	 * @param $id_or_email mixed  The users ID, email, or a WP_User, WP_Post, WP_Comment object.
+	 * @param $args        array  Arguments passed to get_avatar_url(), after processing.
+	 *
+	 * @return string
+	 */
+	public function filter_vip_support_email_gravatars( $url, $id_or_email, $args ) {
+
+		if ( ! is_admin() ) {
+			return $url;
+		}
+
+		// Get the user's email address.
+		if ( is_numeric( $id_or_email ) ) {
+			$user       = get_user_by( 'id', $id_or_email );
+			$user_email = $user->user_email;
+		} elseif ( is_string( $id_or_email ) ) {
+			$user_email = $id_or_email;
+		} elseif ( $id_or_email instanceof WP_User ) {
+			$user_email = $id_or_email->user_email;
+		}
+
+		if ( isset( $user_email ) && $this->is_vip_support_email_alias( $user_email ) ) {
+			$email_hash = md5( self::VIP_SUPPORT_EMAIL_ADDRESS );
+			return sprintf( 'https://secure.gravatar.com/avatar/%s?s=%d&d=mm&r=g', $email_hash, $args['size'] );
+		}
+
+		return $url;
 	}
 
 	/**
@@ -655,6 +718,21 @@ class User {
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Is the email provided a VIP Support email alias.
+	 *
+	 * VIP Support staff without a real a8c email addresses will receive
+	 * an email address like `vip-support+<username>@automattic.com`.
+	 *
+	 * @param string $email an email address to check.
+	 *
+	 * @return bool true if the string is a VIP support email alias.
+	 */
+	public function is_vip_support_email_alias( $email ) {
+		$email_pattern = str_replace( [ '.', '@' ], [ '\.', '\+(.*)@' ], self::VIP_SUPPORT_EMAIL_ADDRESS );
+		return (bool) preg_match( "/{$email_pattern}/i", $email );
 	}
 
 	/**

--- a/class-vip-support-user.php
+++ b/class-vip-support-user.php
@@ -105,6 +105,11 @@ class User {
 	const VIP_SUPPORT_EMAIL_ADDRESS_PATTERN = '/vip-support\+[^@]+@automattic\.com/i';
 
 	/**
+	 * The Gravatar URL for `VIP_SUPPORT_EMAIL_ADDRESS`.
+	 */
+	const VIP_SUPPORT_EMAIL_ADDRESS_GRAVATAR = 'https://secure.gravatar.com/avatar/c83fd21f1122c4d1d8677d6a7a1291d3';
+
+	/**
 	 * A flag to indicate reversion and then to prevent recursion.
 	 *
 	 * @var bool True if the role is being reverted
@@ -463,7 +468,7 @@ class User {
 
 		if ( isset( $user_email ) && $this->is_vip_support_email_alias( $user_email ) ) {
 			$email_hash = md5( self::VIP_SUPPORT_EMAIL_ADDRESS );
-			return sprintf( 'https://secure.gravatar.com/avatar/%s?s=%d&d=mm&r=g', $email_hash, $args['size'] );
+			return self::VIP_SUPPORT_EMAIL_ADDRESS_GRAVATAR . '?d=mm&r=g&s=' . $args['size'];
 		}
 
 		return $url;

--- a/class-vip-support-user.php
+++ b/class-vip-support-user.php
@@ -99,6 +99,12 @@ class User {
 	const VIP_SUPPORT_EMAIL_ADDRESS = 'vip-support@automattic.com';
 
 	/**
+	 * Regex Pattern for `VIP_SUPPORT_EMAIL_ADDRESS` to match aliases like:
+	 * `vip-support+<username>@automattic.com`
+	 */
+	const VIP_SUPPORT_EMAIL_ADDRESS_PATTERN = '/vip-support\+(.*)@automattic\.com/i';
+
+	/**
 	 * A flag to indicate reversion and then to prevent recursion.
 	 *
 	 * @var bool True if the role is being reverted
@@ -731,8 +737,7 @@ class User {
 	 * @return bool true if the string is a VIP support email alias.
 	 */
 	public function is_vip_support_email_alias( $email ) {
-		$email_pattern = str_replace( [ '.', '@' ], [ '\.', '\+(.*)@' ], self::VIP_SUPPORT_EMAIL_ADDRESS );
-		return (bool) preg_match( "/{$email_pattern}/i", $email );
+		return (bool) preg_match( self::VIP_SUPPORT_EMAIL_ADDRESS_PATTERN, $email );
 	}
 
 	/**

--- a/tests/test-user.php
+++ b/tests/test-user.php
@@ -74,6 +74,20 @@ class VIPSupportUserTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The emails used in `test_is_vip_support_email_alias_*()` tests pressume the values of
+	 * `User::VIP_SUPPORT_EMAIL_ADDRESS` and `Users::VIP_SUPPORT_EMAIL_ADDRESS_PATTERN`.
+	 * If either of those constants changes the values in tests must also change as well.
+	 * This test attempts to make that more clear.
+	 */
+	function test_vip_support_email_pattern_constant_for_tests() {
+		$this->assertEquals(
+			'/vip-support\+(.*)@automattic\.com/i',
+			User::VIP_SUPPORT_EMAIL_ADDRESS_PATTERN,
+			"`VIP_SUPPORT_EMAIL_ADDRESS_PATTERN` has changed. The data providers for the two `test_is_vip_support_email_alias_*()` tests, and this test need to be changed as well to reflect the new email address."
+		);
+	}
+
+	/**
 	 * @dataProvider provider_valid_vip_support_email_aliases
 	 */
 	function test_is_vip_support_email_alias_valid( $valid_email_aliases  ) {

--- a/tests/test-user.php
+++ b/tests/test-user.php
@@ -66,7 +66,11 @@ class VIPSupportUserTest extends WP_UnitTestCase {
 	 * tests must also change as well. This test attempts to make that more clear.
 	 */
 	function test_vip_support_email_constant_for_tests() {
-		$this->assertEquals( 'vip-support@automattic.com', User::VIP_SUPPORT_EMAIL_ADDRESS );
+		$this->assertEquals(
+			'vip-support@automattic.com',
+			User::VIP_SUPPORT_EMAIL_ADDRESS,
+			"`VIP_SUPPORT_EMAIL_ADDRESS` has changed. The data providers for the two `test_is_vip_support_email_alias_*()` tests, and this test need to be changed as well to reflect this new email address."
+		);
 	}
 
 	/**

--- a/tests/test-user.php
+++ b/tests/test-user.php
@@ -81,7 +81,7 @@ class VIPSupportUserTest extends WP_UnitTestCase {
 	 */
 	function test_vip_support_email_pattern_constant_for_tests() {
 		$this->assertEquals(
-			'/vip-support\+(.*)@automattic\.com/i',
+			'/vip-support\+[^@]+@automattic\.com/i',
 			User::VIP_SUPPORT_EMAIL_ADDRESS_PATTERN,
 			"`VIP_SUPPORT_EMAIL_ADDRESS_PATTERN` has changed. The data providers for the two `test_is_vip_support_email_alias_*()` tests, and this test need to be changed as well to reflect the new email address."
 		);

--- a/tests/test-user.php
+++ b/tests/test-user.php
@@ -61,38 +61,49 @@ class VIPSupportUserTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The values in `test_is_vip_support_email_alias()` pressume the value of
-	 * `User::VIP_SUPPORT_EMAIL_ADDRESS`. If that value changes the values in these
+	 * The values in `test_is_vip_support_email_alias_*()` pressumes the value of
+	 * `User::VIP_SUPPORT_EMAIL_ADDRESS`. If that constants value changes the values in these
 	 * tests must also change as well. This test attempts to make that more clear.
 	 */
 	function test_vip_support_email_constant_for_tests() {
 		$this->assertEquals( 'vip-support@automattic.com', User::VIP_SUPPORT_EMAIL_ADDRESS );
 	}
 
-	function test_is_vip_support_email_alias() {
+	/**
+	 * @dataProvider provider_valid_vip_support_email_aliases
+	 */
+	function test_is_vip_support_email_alias_valid( $valid_email_aliases  ) {
+		foreach ( $valid_email_aliases as $valid_email_alias ) {
+			$this->assertTrue( User::init()->is_vip_support_email_alias( $valid_email_alias ) );
+		}
+	}
 
-		$support_email_aliases = array(
+	function provider_valid_vip_support_email_aliases() {
+		return [ [ [
 			'vip-support+test@automattic.com',
 			'vip-support+some_username@automattic.com',
-		);
+			'vip-support+areallylongusernameusedhere123@automattic.com',
+		] ] ];
+	}
 
-		foreach ( $support_email_aliases as $support_email_alias ) {
-			$this->assertTrue( User::init()->is_vip_support_email_alias( $support_email_alias ) );
+	/**
+	 * @dataProvider provider_invalid_vip_support_email_aliases
+	 */
+	function test_is_vip_support_email_alias_invalid( $invalid_email_aliases ) {
+		foreach ( $invalid_email_aliases as $invalid_email_alias ) {
+			$this->assertFalse( User::init()->is_vip_support_email_alias( $invalid_email_alias ) );
 		}
+	}
 
-		$non_support_email_aliases = array(
+	function provider_invalid_vip_support_email_aliases() {
+		return [ [ [
 			'someone@example.com',
 			'someone@automattic',
 			'someone@automattic.com',
 			'vip+test@example.com',
 			'vip-support+test@example.com',
 			'vip-support@example.com',
-		);
-
-		foreach ( $non_support_email_aliases as $non_support_email_alias ) {
-			$this->assertFalse( User::init()->is_vip_support_email_alias( $non_support_email_alias ) );
-		}
-
+		] ] ];
 	}
 
 	/**

--- a/tests/test-user.php
+++ b/tests/test-user.php
@@ -61,6 +61,41 @@ class VIPSupportUserTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The values in `test_is_vip_support_email_alias()` pressume the value of
+	 * `User::VIP_SUPPORT_EMAIL_ADDRESS`. If that value changes the values in these
+	 * tests must also change as well. This test attempts to make that more clear.
+	 */
+	function test_vip_support_email_constant_for_tests() {
+		$this->assertEquals( 'vip-support@automattic.com', User::VIP_SUPPORT_EMAIL_ADDRESS );
+	}
+
+	function test_is_vip_support_email_alias() {
+
+		$support_email_aliases = array(
+			'vip-support+test@automattic.com',
+			'vip-support+some_username@automattic.com',
+		);
+
+		foreach ( $support_email_aliases as $support_email_alias ) {
+			$this->assertTrue( User::init()->is_vip_support_email_alias( $support_email_alias ) );
+		}
+
+		$non_support_email_aliases = array(
+			'someone@example.com',
+			'someone@automattic',
+			'someone@automattic.com',
+			'vip+test@example.com',
+			'vip-support+test@example.com',
+			'vip-support@example.com',
+		);
+
+		foreach ( $non_support_email_aliases as $non_support_email_alias ) {
+			$this->assertFalse( User::init()->is_vip_support_email_alias( $non_support_email_alias ) );
+		}
+
+	}
+
+	/**
 	 * Test that cron callback is registered properly
 	 */
 	function test_cron_cleanup_has_callback() {


### PR DESCRIPTION
Adds support for VIP Support email aliases.

Currently a VIP Support user with an email address of `vip-support+<username>@automattic.com` would appear like this:

![1](https://user-images.githubusercontent.com/1996370/52383411-1cb50b80-2a2e-11e9-9b34-8ad4592cd6d2.png)

This PR masks these addresses to appear as `vip-support@automattic.com` when outputting, and also masks the Gravatar URL to `vip-support@automattic.com`.

![2](https://user-images.githubusercontent.com/1996370/52383435-38b8ad00-2a2e-11e9-8a32-4632c348a919.png)

Added to help clearly brand VIP staff who don't have an a8c email addresses and will receive these support email aliases.

Note that `vip-support@automattic.com` does not currently have a Gravatar setup, so mystery man will appear until then (but you can double check the `md5()` hash for `vip-support@automattic.com` is `c83fd21f1122c4d1d8677d6a7a1291d3`).