### PR TITLE
Fix/hide personal emails

### DIFF
--- a/class-vip-support-user.php
+++ b/class-vip-support-user.php
@@ -99,12 +99,6 @@ class User {
 	const VIP_SUPPORT_EMAIL_ADDRESS = 'vip-support@automattic.com';
 
 	/**
-	 * Regex Pattern for `VIP_SUPPORT_EMAIL_ADDRESS` to match aliases like:
-	 * `vip-support+<username>@automattic.com`
-	 */
-	const VIP_SUPPORT_EMAIL_ADDRESS_PATTERN = '/vip-support\+[^@]+@automattic\.com/i';
-
-	/**
 	 * The Gravatar URL for `VIP_SUPPORT_EMAIL_ADDRESS`.
 	 */
 	const VIP_SUPPORT_EMAIL_ADDRESS_GRAVATAR = 'https://secure.gravatar.com/avatar/c83fd21f1122c4d1d8677d6a7a1291d3';
@@ -728,20 +722,6 @@ class User {
 			return true;
 		}
 		return false;
-	}
-
-	/**
-	 * Is the email provided a VIP Support email alias.
-	 *
-	 * VIP Support staff without a real a8c email addresses will receive
-	 * an email address like `vip-support+<username>@automattic.com`.
-	 *
-	 * @param string $email an email address to check.
-	 *
-	 * @return bool true if the string is a VIP support email alias.
-	 */
-	public function is_vip_support_email_alias( $email ) {
-		return (bool) preg_match( self::VIP_SUPPORT_EMAIL_ADDRESS_PATTERN, $email );
 	}
 
 	/**

--- a/class-vip-support-user.php
+++ b/class-vip-support-user.php
@@ -430,7 +430,7 @@ class User {
 	 * @return string
 	 */
 	public function filter_vip_support_email_aliases( $email ) {
-		if ( is_admin() && $this->is_vip_support_email_alias( $email ) ) {
+		if ( is_admin() && $this->is_a8c_email( $email ) ) {
 			return self::VIP_SUPPORT_EMAIL_ADDRESS;
 		}
 		return $email;
@@ -466,7 +466,7 @@ class User {
 			$user_email = $id_or_email->user_email;
 		}
 
-		if ( isset( $user_email ) && $this->is_vip_support_email_alias( $user_email ) ) {
+		if ( isset( $user_email ) && $this->is_a8c_email( $user_email ) ) {
 			return self::VIP_SUPPORT_EMAIL_ADDRESS_GRAVATAR . '?d=mm&r=g&s=' . $args['size'];
 		}
 

--- a/tests/test-user.php
+++ b/tests/test-user.php
@@ -60,57 +60,12 @@ class VIPSupportUserTest extends WP_UnitTestCase {
 
 	}
 
-	/**
-	 * The values in `test_is_vip_support_email_alias_*()` pressumes the value of
-	 * `User::VIP_SUPPORT_EMAIL_ADDRESS`. If that constants value changes the values in these
-	 * tests must also change as well. This test attempts to make that more clear.
-	 */
-	function test_vip_support_email_constant_for_tests() {
-		$this->assertEquals(
-			'vip-support@automattic.com',
-			User::VIP_SUPPORT_EMAIL_ADDRESS,
-			"`VIP_SUPPORT_EMAIL_ADDRESS` has changed. The data providers for the two `test_is_vip_support_email_alias_*()` tests, and this test need to be changed as well to reflect this new email address."
-		);
-	}
-
-	/**
-	 * The emails used in `test_is_vip_support_email_alias_*()` tests pressume the values of
-	 * `User::VIP_SUPPORT_EMAIL_ADDRESS` and `Users::VIP_SUPPORT_EMAIL_ADDRESS_PATTERN`.
-	 * If either of those constants changes the values in tests must also change as well.
-	 * This test attempts to make that more clear.
-	 */
-	function test_vip_support_email_pattern_constant_for_tests() {
-		$this->assertEquals(
-			'/vip-support\+[^@]+@automattic\.com/i',
-			User::VIP_SUPPORT_EMAIL_ADDRESS_PATTERN,
-			"`VIP_SUPPORT_EMAIL_ADDRESS_PATTERN` has changed. The data providers for the two `test_is_vip_support_email_alias_*()` tests, and this test need to be changed as well to reflect the new email address."
-		);
-	}
-
-	/**
-	 * @dataProvider provider_valid_vip_support_email_aliases
-	 */
-	function test_is_vip_support_email_alias_valid( $valid_email_aliases  ) {
-		foreach ( $valid_email_aliases as $valid_email_alias ) {
-			$this->assertTrue( User::init()->is_vip_support_email_alias( $valid_email_alias ) );
-		}
-	}
-
 	function provider_valid_vip_support_email_aliases() {
 		return [ [ [
 			'vip-support+test@automattic.com',
 			'vip-support+some_username@automattic.com',
 			'vip-support+areallylongusernameusedhere123@automattic.com',
 		] ] ];
-	}
-
-	/**
-	 * @dataProvider provider_invalid_vip_support_email_aliases
-	 */
-	function test_is_vip_support_email_alias_invalid( $invalid_email_aliases ) {
-		foreach ( $invalid_email_aliases as $invalid_email_alias ) {
-			$this->assertFalse( User::init()->is_vip_support_email_alias( $invalid_email_alias ) );
-		}
 	}
 
 	function provider_invalid_vip_support_email_aliases() {


### PR DESCRIPTION
for #66

Hides/masks personal email addresses using `vip-support@automattic.com` instead in main Users list for VIP Support users with a8c email addresses. Gravatars also change to become generic VIP one as well.

There's no need to verify support aliases any more (re https://github.com/Automattic/vip-support/pull/73) since the "fake" alias emails will be included via the `is_a8c_email()` method, so removed `is_vip_support_email_alias` logic and tests.

```
$ wp vipsupport create-user johndoe john.doe@automattic.com password
```

Displays in a single site as:

<img width="911" alt="Screen Shot 2019-03-12 at 3 28 55 PM" src="https://user-images.githubusercontent.com/1996370/54241023-1c040f00-44dd-11e9-8845-aca384e27cf3.png">

Would work for any of valid `is_a8c_email()` email domains.

Note this [does not](https://github.com/Automattic/vip-support/pull/73/#issuecomment-465704177) work on multisite/network setups. 