### PR TITLE
Verify user is sucessfully found before using

### DIFF
--- a/class-vip-support-user.php
+++ b/class-vip-support-user.php
@@ -459,7 +459,9 @@ class User {
 		// Get the user's email address.
 		if ( is_numeric( $id_or_email ) ) {
 			$user       = get_user_by( 'id', $id_or_email );
-			$user_email = $user->user_email;
+			if ( false !== $user ) {
+				$user_email = $user->user_email;
+			}
 		} elseif ( is_string( $id_or_email ) ) {
 			$user_email = $id_or_email;
 		} elseif ( $id_or_email instanceof WP_User ) {


### PR DESCRIPTION
otherwise a `Trying to get property 'user_email' of non-object` warning may occur.

context: 90505-zd