### PR TITLE
When creating a support user, default the locale to en_US

### DIFF
--- a/class-vip-support-cli.php
+++ b/class-vip-support-cli.php
@@ -46,6 +46,7 @@ class Command extends WP_CLI_Command {
 		$user_data['display_name'] = $display_name;
 		$user_data['first_name'] = ! empty( $display_name ) ? $display_name : $user_login;
 		$user_data['last_name'] = '(VIP Support)';
+		$user_data['locale'] = 'en_US';
 
 		$user_id = User::add( $user_data );
 


### PR DESCRIPTION
## Description
When we create a new VIP Support user, set their locale to en_US (rather than it using whatever the site default is set to)

Fixes: #82 