### PR TITLE
Don't add roles on init

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,8 @@ job-references:
   install_dependencies: &install_dependencies
     name: "Install Dependencies"
     command: |
-      sudo apt-get update && sudo apt-get install subversion
-      sudo -E docker-php-ext-install mysqli
-      sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
-      sudo apt-get update && sudo apt-get install mysql-client
+      sudo apt-get update && sudo apt-get install subversion libgcc-8-dev default-mysql-client
+      sudo -E docker-php-ext-install mysqli 
       composer install -n
 
   prepare_repo: &prepare_repo

--- a/bin/download-wp-tests.sh
+++ b/bin/download-wp-tests.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 if [ $# -lt 3 ]; then
 	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
 	exit 1
@@ -20,7 +22,10 @@ download() {
     fi
 }
 
-if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
+
+if [[ $WP_VERSION == 'nightly' ]]; then
+	WP_TESTS_TAG="trunk"
+elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
 	WP_TESTS_TAG="tags/$WP_VERSION"
 else
 	# http serves a single offer, whereas https serves multiple. we only want one
@@ -60,9 +65,18 @@ install_wp() {
 		local ARCHIVE_NAME="wordpress-$WP_VERSION"
 	fi
 
-	download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
-	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR_ACTUAL
-
+	if [ $WP_VERSION == 'nightly' ]; then
+		local ARCHIVE_NAME='nightly-builds/wordpress-latest'
+		download https://wordpress.org/${ARCHIVE_NAME}.zip  /tmp/wordpress.zip
+		unzip -qq /tmp/wordpress.zip -d /tmp
+		cd /tmp/wordpress
+		cp -r . $WP_CORE_DIR_ACTUAL
+		rm -rf /tmp/wordpress
+	else
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
+		tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR_ACTUAL
+	fi
+	
 	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR_ACTUAL/wp-content/db.php
 }
 
@@ -78,20 +92,22 @@ install_test_suite() {
 	if [ ! -d $WP_TESTS_DIR_ACTUAL ]; then
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR_ACTUAL
-		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR_ACTUAL/includes
-		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR_ACTUAL/data
+		svn co --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR_ACTUAL/includes
+		svn co --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR_ACTUAL/data
 	fi
 
 	cd $WP_TESTS_DIR_ACTUAL
 
-	if [ ! -f wp-tests-config.php ]; then
-		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
-		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
-		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
-		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
-		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
-		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
-	fi
+	# Always start from a clean config
+	rm -f wp-tests-config.php
+
+	# Set up the config file
+	download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+	sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+	sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+	sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+	sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+	sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
 
 }
 

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -5,34 +5,20 @@ if [ $# -lt 3 ]; then
 	exit 1
 fi
 
+source "$(dirname $0)"/utils.sh
+
 DB_NAME=$1
 DB_USER=$2
 DB_PASS=$3
 DB_HOST=${4-localhost}
-WP_VERSION=${5-latest}
+
+if [[ $5 == 'nightly' ]]; then
+	WP_VERSION='nightly'
+else
+	WP_VERSION=${5-latest}
+fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 $DIR/download-wp-tests.sh "$DB_NAME" "$DB_USER" "$DB_PASS" "$DB_HOST" "$WP_VERSION"
 
-install_db() {
-	# parse DB_HOST for port or socket references
-	local PARTS=(${DB_HOST//\:/ })
-	local DB_HOSTNAME=${PARTS[0]};
-	local DB_SOCK_OR_PORT=${PARTS[1]};
-	local EXTRA=""
-
-	if ! [ -z $DB_HOSTNAME ] ; then
-		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
-			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
-		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
-			EXTRA=" --socket=$DB_SOCK_OR_PORT"
-		elif ! [ -z $DB_HOSTNAME ] ; then
-			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
-		fi
-	fi
-
-	# create database
-	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
-}
-
-install_db
+install_db "$DB_NAME" "$DB_USER" "$DB_PASS" "$DB_HOST"

--- a/bin/phpunit-docker.sh
+++ b/bin/phpunit-docker.sh
@@ -1,29 +1,48 @@
 #!/bin/bash
 
-WP_VERSION=${1-latest}
+# Note: you can pass in additional phpunit args
+# Test a specific file: ./bin/phpunit-docker.sh tests/path/to/test.php
+# Stop on failures: ./bin/phpunit-docker.sh --stop-on-failure
+# etc.
 
+WP_VERSION=${2-latest}
+WP_MULTISITE=${3-0}
+
+echo "--------------"
+echo "Will test with WP_VERSION=$WP_VERSION and WP_MULTISITE=$WP_MULTISITE"
+echo "--------------"
+echo
+
+MARIADB_VERSION="10.3"
+UUID=`date +%s000`
+NETWORK_NAME="tests-$UUID"
+DB_CONTAINER_NAME="db-$UUID"
 MYSQL_ROOT_PASSWORD='wordpress'
-docker network create tests
-db=$(docker run --network tests --name db -e MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD -d mariadb)
+
+docker network create $NETWORK_NAME
+
+db=$(docker run --network $NETWORK_NAME --name $DB_CONTAINER_NAME -e MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD -d mariadb/server:$MARIADB_VERSION)
 function cleanup() {
+	echo "cleanup!"
 	docker rm -f $db
-	docker network rm tests
+	docker network rm $NETWORK_NAME
 }
 trap cleanup EXIT
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-WP_VERSION=$($DIR/download-wp-tests.sh wordpress_test root "$MYSQL_ROOT_PASSWORD" "db" "$WP_VERSION")
+WP_VERSION=$($DIR/download-wp-tests.sh wordpress_test root "$MYSQL_ROOT_PASSWORD" "$DB_CONTAINER_NAME" "$WP_VERSION")
 
 ## Ensure there's a database connection for the rest of the steps
-until docker exec -it $db mysql -u root -h db --password="wordpress" -e 'CREATE DATABASE wordpress_test' > /dev/null; do
+until docker exec -it $db mysql -u root -h $DB_CONTAINER_NAME --password="wordpress" -e 'CREATE DATABASE wordpress_test' > /dev/null; do
 	echo "Waiting for database connection..."
 	sleep 5
 done
 
 docker run \
- 	--network tests \
+	--network $NETWORK_NAME \
+	-e WP_MULTISITE="$WP_MULTISITE" \
 	-v $(pwd):/app \
 	-v /tmp/wordpress-tests-lib-$WP_VERSION:/tmp/wordpress-tests-lib \
 	-v /tmp/wordpress-$WP_VERSION:/tmp/wordpress \
 	--rm phpunit/phpunit \
-	--bootstrap /app/tests/bootstrap.php
+	--bootstrap /app/tests/bootstrap.php "$@"

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+# Utils script to unify code used by other scripts
+
+install_db() {
+	local DB_NAME=$1
+	local DB_USER=$2
+	local DB_PASS=$3
+	local DB_HOST=${4-localhost}
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+exclude_core_tests() {
+	local FILE=$1
+	local PREFIX=$2 || ""
+	local TO_EXCLUDE=(
+		"tests/admin/includesPlugin.php"
+		"tests/admin/includesScreen.php"
+		"tests/adminbar.php"
+		"tests/canonical/sitemaps.php"
+		"tests/comment/wpCountComments.php"
+		"tests/customize/custom-css-setting.php"
+		"tests/customize/widgets.php"
+		"tests/date/getFeedBuildDate.php"
+		"tests/dependencies/scripts.php"
+		"tests/feed/atom.php"
+		"tests/feed/rss2.php"
+		"tests/filesystem/base.php"
+		"tests/filesystem/findFolder.php"
+		"tests/import/import.php"
+		"tests/import/parser.php"
+		"tests/import/postmeta.php"
+		"tests/mail.php"
+		"tests/multisite/getSpaceAllowed.php"
+		"tests/multisite/site.php"
+		"tests/option/updateOption.php"
+		"tests/post/getLastPostModified.php"
+		"tests/privacy/wpPrivacySendErasureFulfillmentNotification.php"
+		"tests/privacy/wpPrivacySendPersonalDataExportEmail.php"
+		"tests/privacy/wpPrivacySendRequestConfirmationNotification.php"
+		"tests/query/isTerm.php"
+		"tests/query/search.php"
+		"tests/query/vars.php"
+		"tests/rest-api/rest-attachments-controller.php"
+		"tests/rest-api/rest-posts-controller.php"
+		"tests/rest-api/rest-schema-setup.php"
+		"tests/rest-api/rest-users-controller.php"
+		"tests/sitemaps/functions.php"
+		"tests/sitemaps/sitemaps.php"
+		"tests/taxonomy.php"
+		"tests/term.php"
+		"tests/term/cache.php"
+		"tests/term/getTerm.php"
+		"tests/term/getTerms.php"
+		"tests/term/getTheTerms.php"
+		"tests/term/query.php"
+		"tests/term/splitSharedTerm.php"
+		"tests/term/termCounts.php"
+		"tests/term/wpDeleteTerm.php"
+		"tests/term/wpGetObjectTerms.php"
+		"tests/user/capabilities.php"
+		"tests/user/wpSendUserRequest.php"
+		"tests/xmlrpc/basic.php"
+		"tests/xmlrpc/wp/getUser.php"
+	);
+
+	for testFile in "${TO_EXCLUDE[@]}"; do
+		sed -i "/<testsuite name=\"default\">/a <exclude>${PREFIX}${testFile}</exclude>" "$FILE"
+	done
+}
+
+update_core_tests() {
+	local wp_tests_dir="$1"
+
+	if [ -z "$wp_tests_dir" ]; then
+		echo "WP_TESTS_DIR was not passed in";
+		exit 1;
+	fi
+
+
+	local header_handling_locations=(
+		"$wp_tests_dir/tests/xmlrpc/wp/newComment.php:Tests_XMLRPC_wp_newComment"
+		"$wp_tests_dir/tests/xmlrpc/mt/getRecentPostTitles.php:Tests_XMLRPC_mt_getRecentPostTitles"
+		"$wp_tests_dir/tests/xmlrpc/wp/restoreRevision.php:Tests_XMLRPC_wp_restoreRevision"
+		"$wp_tests_dir/tests/xmlrpc/wp/newTerm.php:Tests_XMLRPC_wp_newTerm"
+		"$wp_tests_dir/tests/xmlrpc/wp/newPost.php:Tests_XMLRPC_wp_newPost"
+		"$wp_tests_dir/tests/xmlrpc/wp/getUsers.php:Tests_XMLRPC_wp_getUsers"
+		"$wp_tests_dir/tests/xmlrpc/wp/getTerms.php:Tests_XMLRPC_wp_getTerms"
+		"$wp_tests_dir/tests/xmlrpc/wp/getTerm.php:Tests_XMLRPC_wp_getTerm"
+		"$wp_tests_dir/tests/xmlrpc/wp/getTaxonomy.php:Tests_XMLRPC_wp_getTaxonomy"
+		"$wp_tests_dir/tests/xmlrpc/wp/getTaxonomies.php:Tests_XMLRPC_wp_getTaxonomies"
+		"$wp_tests_dir/tests/xmlrpc/wp/getRevisions.php:Tests_XMLRPC_wp_getRevisions"
+		"$wp_tests_dir/tests/xmlrpc/wp/getProfile.php:Tests_XMLRPC_wp_getProfile"
+		"$wp_tests_dir/tests/xmlrpc/wp/getPosts.php:Tests_XMLRPC_wp_getPosts"
+		"$wp_tests_dir/tests/xmlrpc/wp/getPostTypes.php:Tests_XMLRPC_wp_getPostTypes"
+		"$wp_tests_dir/tests/xmlrpc/wp/getPostType.php:Tests_XMLRPC_wp_getPostType"
+		"$wp_tests_dir/tests/xmlrpc/wp/getPost.php:Tests_XMLRPC_wp_getPost"
+		"$wp_tests_dir/tests/xmlrpc/wp/getPages.php:Tests_XMLRPC_wp_getPages"
+		"$wp_tests_dir/tests/xmlrpc/wp/getPageList.php:Tests_XMLRPC_wp_getPageList"
+		"$wp_tests_dir/tests/xmlrpc/wp/getPage.php:Tests_XMLRPC_wp_getPage"
+		"$wp_tests_dir/tests/xmlrpc/wp/getOptions.php:Tests_XMLRPC_wp_getOptions"
+		"$wp_tests_dir/tests/xmlrpc/wp/getMediaItem.php:Tests_XMLRPC_wp_getMediaItem"
+		"$wp_tests_dir/tests/xmlrpc/wp/getComments.php:Tests_XMLRPC_wp_getComments"
+		"$wp_tests_dir/tests/xmlrpc/wp/getComment.php:Tests_XMLRPC_wp_getComment"
+		"$wp_tests_dir/tests/xmlrpc/wp/editTerm.php:Tests_XMLRPC_wp_editTerm"
+		"$wp_tests_dir/tests/xmlrpc/wp/editProfile.php:Tests_XMLRPC_wp_editProfile"
+		"$wp_tests_dir/tests/xmlrpc/wp/editPost.php:Tests_XMLRPC_wp_editPost"
+		"$wp_tests_dir/tests/xmlrpc/wp/deleteTerm.php:Tests_XMLRPC_wp_deleteTerm"
+		"$wp_tests_dir/tests/xmlrpc/wp/deletePost.php:Tests_XMLRPC_wp_deletePost"
+		"$wp_tests_dir/tests/xmlrpc/mw/newPost.php:Tests_XMLRPC_mw_newPost"
+		"$wp_tests_dir/tests/xmlrpc/mw/getRecentPosts.php:Tests_XMLRPC_mw_getRecentPosts"
+		"$wp_tests_dir/tests/xmlrpc/mw/getPost.php:Tests_XMLRPC_mw_getPost"
+		"$wp_tests_dir/tests/xmlrpc/mw/editPost.php:Tests_XMLRPC_mw_editPost"
+	)
+
+	local header_handling='\/**\n * @runTestsInSeparateProcesses\n * @preserveGlobalState disabled\n *\/'
+
+	for location in "${header_handling_locations[@]}"; do
+		local location_data=(${location//:/ })
+		local file="${location_data[0]}"
+		local test_class_name="${location_data[1]}"
+
+		echo "Updating ${file} - ${test_class_name} for header test"
+		sed -i "s/\\(class $test_class_name\\)/${header_handling}\\n\\1/" "$file"
+	done
+}
+
+export -f install_db
+export -f exclude_core_tests
+export -f update_core_tests

--- a/class-vip-support-cli.php
+++ b/class-vip-support-cli.php
@@ -87,7 +87,6 @@ class Command extends WP_CLI_Command {
 	/**
 	 * Marks the user with the provided ID as having a verified email.
 	 *
-	 *
 	 * <user-id>
 	 * : The WP User ID to mark as having a verified email address
 	 *
@@ -119,6 +118,23 @@ class Command extends WP_CLI_Command {
 
 		// Print a success message
 		\WP_CLI::success( "Verified user $user_id with email {$user->user_email}, you can now change their role to VIP Support" );
+	}
+
+	/**
+	 * Reset / re-add VIP Support related roles.
+	 *
+	 * @subcommand reset-roles
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp vipsupport reset-roles
+	 */
+	public function reset_roles( $args ) {
+		delete_option( 'vipsupportrole_version' );
+
+		Role::init()->maybe_upgrade_version();
+
+		\WP_CLI::success( __( 'VIP Support roles successfully reset' ) );
 	}
 
 }

--- a/class-vip-support-role.php
+++ b/class-vip-support-role.php
@@ -76,7 +76,7 @@ class Role {
 	 * Hooks the admin_init action to run an update method.
 	 */
 	public function action_admin_init() {
-		$this->update();
+		$this->maybe_upgrade_version();
 	}
 
 	/**
@@ -139,22 +139,16 @@ class Role {
 
 	}
 
-	protected static function add_role() {
-		if ( function_exists( 'wpcom_vip_add_role' ) ) {
-			wpcom_vip_add_role( self::VIP_SUPPORT_ROLE, __( 'VIP Support', 'a8c_vip_support' ), array( 'read' => true ) );
-			wpcom_vip_add_role( self::VIP_SUPPORT_INACTIVE_ROLE, __( 'VIP Support (inactive)', 'a8c_vip_support' ), array( 'read' => true ) );
-		} else {
-			add_role( self::VIP_SUPPORT_ROLE, __( 'VIP Support', 'a8c_vip_support' ), array( 'read' => true ) );
-			add_role( self::VIP_SUPPORT_INACTIVE_ROLE, __( 'VIP Support (inactive)', 'a8c_vip_support' ), array( 'read' => true ) );
-		}
+	protected static function add_roles() {
+		add_role( self::VIP_SUPPORT_ROLE, __( 'VIP Support', 'a8c_vip_support' ), array( 'read' => true ) );
+		add_role( self::VIP_SUPPORT_INACTIVE_ROLE, __( 'VIP Support (inactive)', 'a8c_vip_support' ), array( 'read' => true ) );
 	}
 
 	/**
 	 * Checks the version option value against the version
 	 * property value, and runs update routines as appropriate.
-	 *
 	 */
-	protected function update() {
+	public function maybe_upgrade_version() {
 		$option_name = 'vipsupportrole_version';
 		$version = absint( get_option( $option_name, 0 ) );
 
@@ -162,8 +156,8 @@ class Role {
 			return;
 		}
 
-		if ( $version < 1 && function_exists( 'wpcom_vip_add_role' ) ) {
-			self::add_role();
+		if ( $version < 1 ) {
+			self::add_roles();
 			self::error_log( "VIP Support Role: Added VIP Support role " );
 		}
 

--- a/class-vip-support-role.php
+++ b/class-vip-support-role.php
@@ -114,13 +114,20 @@ class Role {
 	 * @return array An array of WP role data
 	 */
 	public function filter_editable_roles( array $roles ) {
-		$vip_support_roles = array(
-			self::VIP_SUPPORT_INACTIVE_ROLE => $roles[self::VIP_SUPPORT_INACTIVE_ROLE],
-			self::VIP_SUPPORT_ROLE => $roles[self::VIP_SUPPORT_ROLE],
-		);
-		unset( $roles[self::VIP_SUPPORT_INACTIVE_ROLE] );
-		unset( $roles[self::VIP_SUPPORT_ROLE] );
+		$vip_support_roles = array();
+
+		if ( isset( $roles[ self::VIP_SUPPORT_INACTIVE_ROLE ] ) ) {
+			$vip_support_roles[ self::VIP_SUPPORT_INACTIVE_ROLE ] = $roles[ self::VIP_SUPPORT_INACTIVE_ROLE ];
+			unset( $roles[ self::VIP_SUPPORT_INACTIVE_ROLE ] );
+		}
+
+		if ( isset( $roles[ self::VIP_SUPPORT_ROLE ] ) ) {
+			$vip_support_roles[ self::VIP_SUPPORT_ROLE ] = $roles[ self::VIP_SUPPORT_ROLE ];
+			unset( $roles[ self::VIP_SUPPORT_ROLE ] );
+		}
+
 		$roles = array_merge( $vip_support_roles, $roles );
+
 		return $roles;
 	}
 

--- a/class-vip-support-role.php
+++ b/class-vip-support-role.php
@@ -64,7 +64,6 @@ class Role {
 	 * and sets some properties.
 	 */
 	public function __construct() {
-		add_action( 'init', array( $this, 'action_init' ) );
 		add_action( 'admin_init', array( $this, 'action_admin_init' ) );
 		add_filter( 'editable_roles', array( $this, 'filter_editable_roles' ) );
 		add_filter( 'user_has_cap', array( $this, 'filter_user_has_cap' ), PHP_INT_MAX, 4 );
@@ -72,14 +71,6 @@ class Role {
 
 	// HOOKS
 	// =====
-
-	/**
-	 * Hooks the init action to add the role, covering the cases
-	 * where we should be using `wpcom_vip_add_role`.
-	 */
-	public function action_init() {
-		self::add_role();
-	}
 
 	/**
 	 * Hooks the admin_init action to run an update method.


### PR DESCRIPTION
add_role can lead to front-end writes which are not ideal. It can lead to undesirable circumstances with other roles being removed if there are intermittent database issues.

We still trigger our upgrade routine on `admin_init` so new installs will still get the roles (and there's still a chance for the latter issue to trigger but the likelihood is significantly reduced).

Also includes a convenience WP-CLI command to force run the upgrade routine if needed (`wp vipsupport reset-roles`)

## To Test

On a new install (with PR in place):

1. If you examine the `wp_user_roles` option in the db, in should not include either of the `vip_support_*` roles.
1. Goto wp-admin
1. This should trigger the upgrade routine
1. The `wp_user_roles` option should now have the roles (can also confirm with `wp role list`.

WP-CLI command:

1. Run `wp vipsupport reset-roles`; should result in no changes
1. Run `wp role delete vip_support`. Running `wp role list` should show `vip_support` role missing.
1. Run `wp vipsupport reset-roles` again. `vip_support role should be restored.
