### PR TITLE
Run action_admin_init during WP CLI requests

### DIFF
--- a/class-vip-support-role.php
+++ b/class-vip-support-role.php
@@ -64,7 +64,11 @@ class Role {
 	 * and sets some properties.
 	 */
 	public function __construct() {
-		add_action( 'admin_init', array( $this, 'action_admin_init' ) );
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			add_action( 'wp_loaded', array( $this, 'action_admin_init' ) );
+		} else {
+			add_action( 'admin_init', array( $this, 'action_admin_init' ) );
+		}
 		add_filter( 'editable_roles', array( $this, 'filter_editable_roles' ) );
 		add_filter( 'user_has_cap', array( $this, 'filter_user_has_cap' ), PHP_INT_MAX, 4 );
 	}


### PR DESCRIPTION
Fix #90 

## Description 

By running this action during WP-CLI requests, we can avoid front-end writes and make sure VIP Support roles and users are added properly through Admin VIP Console. 

The detailed approach is discussed here https://github.com/Automattic/vip-support/issues/90#issuecomment-801691535 with a small change to the `wp_loaded` hook. 

## Tests 

Single site: 

1. Run a WP CLI command to set up WP. Something like this  `wp core install --url=valet-vipgo-3279.test --title=test-vip-support --admin_user=dat --admin_password=dat --admin_email=info@example.com` 
2. Run `wp role list` 
3. Verify that two VIP Supported roles are there 

Multisite: 

1. Run a WP CLI command to set up WP. Something like this  `wp core multisite-install --url=valet-vipgo-3279.test --title=test-vip-support --admin_user=dat --admin_password=dat --admin_email=info@example.com` 
2. Run ` wp role list --url=http://valet-vipgo-3279.test `
3. Verify that two VIP Supported roles are there. 
4. Create a new sub-site `wp site create --slug=subsite-2`.
5. Run `wp role list --url=http://valet-vipgo-3279.test/subsite-2/`
6. Verify that two VIP Supported roles are there.