### PR TITLE
Change home_url to site_url

### DIFF
--- a/class-vip-support-user.php
+++ b/class-vip-support-user.php
@@ -664,13 +664,13 @@ class User {
 
 		$hash              = urlencode( $hash );
 		$user_id           = absint( $user_id );
-		$verification_link = add_query_arg( array( self::GET_EMAIL_VERIFY => urlencode( $hash ), self::GET_EMAIL_USER_LOGIN => urlencode( $user->user_login ) ), home_url() );
+		$verification_link = add_query_arg( array( self::GET_EMAIL_VERIFY => urlencode( $hash ), self::GET_EMAIL_USER_LOGIN => urlencode( $user->user_login ) ), site_url() );
 
 		$user = new WP_User( $user_id );
 
 		$message  = __( 'Dear Automattician,', 'vip-support' );
 		$message .= PHP_EOL . PHP_EOL;
-		$message .= sprintf( __( 'You need to verify your Automattic email address for your user on %1$s (%2$s). If you are expecting this, please click the link below to verify your email address:', 'vip-support' ), get_bloginfo( 'name' ), home_url() );
+		$message .= sprintf( __( 'You need to verify your Automattic email address for your user on %1$s (%2$s). If you are expecting this, please click the link below to verify your email address:', 'vip-support' ), get_bloginfo( 'name' ), site_url() );
 		$message .= PHP_EOL;
 		$message .= esc_url_raw( $verification_link );
 		$message .= PHP_EOL . PHP_EOL;


### PR DESCRIPTION
Howdy 👋 

This fixes some cases where the WP site has different `home_url` and `site_url`. In some decoupled scenarios, the `home_url` lives in a different domain and we end up with an error when clicking the confirmation email.
