### PR TITLE
Add support for restricting allowed users by email

### DIFF
--- a/class-vip-support-user.php
+++ b/class-vip-support-user.php
@@ -728,9 +728,34 @@ class User {
 	}
 
 	/**
+	 * Is a provided email address allowed to be a support user on this site?
+	 * 
+	 * On certain sites with tight access restrictions, only certain support users are allowed
+	 *
+	 * @param string $email An email address to check
+	 *
+	 * @return bool True if the string is an allowed support user
+	 */
+	public function is_allowed_email( $email ) {
+		// If no override is defined, allow
+		if ( ! defined( 'VIP_SUPPORT_USER_ALLOWED_EMAILS' ) ) {
+			return true;
+		}
+		
+		// Incorrectly formatted constant, fail fast + closed
+		if ( ! is_array( VIP_SUPPORT_USER_ALLOWED_EMAILS ) ) {
+			return false;
+		}
+
+		// If the override _is_ present, then the user is only allowed if their email is in the array
+		return isset( VIP_SUPPORT_USER_ALLOWED_EMAILS[ $email ] );
+	}
+
+	/**
 	 * Determine if a given user has been validated as an Automattician
 	 *
-	 * Checks their email address as well as their email address verification status
+	 * Checks their email address as well as their email address verification status. Additionally
+	 * checks to ensure the user is allowed, in case the site has restricted which accounts can be used
 	 *
 	 * @TODO Check the A11n is also proxxied
 	 *
@@ -746,10 +771,11 @@ class User {
 
 		$instance = self::init();
 
-		$is_a8c_email 	= $instance->is_a8c_email( $user->user_email );
-		$email_verified = $instance->user_has_verified_email( $user->ID );
+		$is_a8c_email 	  = $instance->is_a8c_email( $user->user_email );
+		$is_allowed_email = $instance->is_allowed_email( $user->user_email );
+		$email_verified   = $instance->user_has_verified_email( $user->ID );
 
-		return ( $is_a8c_email && $email_verified );
+		return ( $is_a8c_email && $is_allowed_email && $email_verified );
 	}
 
 	public static function has_vip_support_meta( $user_id ) {

--- a/class-vip-support-user.php
+++ b/class-vip-support-user.php
@@ -748,7 +748,7 @@ class User {
 		}
 
 		// If the override _is_ present, then the user is only allowed if their email is in the array
-		return isset( VIP_SUPPORT_USER_ALLOWED_EMAILS[ $email ] );
+		return in_array( $email, VIP_SUPPORT_USER_ALLOWED_EMAILS, true );
 	}
 
 	/**

--- a/tests/test-user.php
+++ b/tests/test-user.php
@@ -105,6 +105,8 @@ class VIPSupportUserTest extends WP_UnitTestCase {
 		] );
 
 		$instance = User::init();
+		
+		$instance->mark_user_email_verified( $user_id, 'admin@automattic.com' );
 
 		$this->assertTrue( $instance->is_verified_automattician( $user_id ) );
 	}
@@ -122,6 +124,8 @@ class VIPSupportUserTest extends WP_UnitTestCase {
 		] );
 
 		$instance = User::init();
+		
+		$instance->mark_user_email_verified( $user_id, 'foo@automattic.com' );
 
 		$this->assertFalse( $instance->is_verified_automattician( $user_id ) );
 	}

--- a/tests/test-user.php
+++ b/tests/test-user.php
@@ -79,6 +79,53 @@ class VIPSupportUserTest extends WP_UnitTestCase {
 		] ] ];
 	}
 
+	function test_is_allowed_email_with_no_config() {
+		$instance = User::init();
+
+		$is_allowed = $this->assertTrue( $instance->is_allowed_email( 'admin@automattic.com' ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	function test_is_allowed_email_with_config() {
+		define( 'VIP_SUPPORT_USER_ALLOWED_EMAILS', array( 'admin@automattic.com' ) );
+
+		$instance = User::init();
+
+		$this->assertTrue( $instance->is_allowed_email( 'admin@automattic.com' ) );
+		$this->assertFalse( $instance->is_allowed_email( 'foo@automattic.com' ) );
+	}
+
+	function test_is_verified_automattician() {
+		$user_id = $this->factory->user->create( [
+			'user_email' => 'admin@automattic.com',
+			'user_login' => 'vip_admin',
+		] );
+
+		$instance = User::init();
+
+		$this->assertTrue( $instance->is_verified_automattician( $user_id ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	function test_is_verified_automattician_for_disallowed_user() {
+		define( 'VIP_SUPPORT_USER_ALLOWED_EMAILS', array( 'admin@automattic.com' ) );
+	
+		$user_id = $this->factory->user->create( [
+			'user_email' => 'foo@automattic.com',
+			'user_login' => 'vip_foo',
+		] );
+
+		$instance = User::init();
+
+		$this->assertFalse( $instance->is_verified_automattician( $user_id ) );
+	}
+
 	/**
 	 * Test that cron callback is registered properly
 	 */


### PR DESCRIPTION
This allows individual sites to restrict which support users have access by defining `VIP_SUPPORT_USER_ALLOWED_EMAILS` to an array of allowed Automattician email addresses.

Can be used to limit VIP Support access to a subset of VIP staff.